### PR TITLE
Define FREESMARTPHONE_GIT variable

### DIFF
--- a/meta-multimedia/recipes-dvb/wscan/wscan_20121111.bb
+++ b/meta-multimedia/recipes-dvb/wscan/wscan_20121111.bb
@@ -1,0 +1,16 @@
+SUMMARY = "Wscan is an ATSC/DVB-C/S/T channel scanner that doesn't require an initial frequency table"
+HOMEPAGE = "http://wirbel.htpc-forum.de/w_scan/index2.html"
+
+LICENSE = "GPLv2"
+LIC_FILES_CHKSUM = "file://COPYING;md5=892f569a555ba9c07a568a7c0c4fa63a"
+
+SRC_URI = "http://wirbel.htpc-forum.de/w_scan/w_scan-${PV}.tar.bz2"
+SRC_URI[md5sum] = "30da05747fed9988e11ebc7745f5e71f"
+SRC_URI[sha256sum] = "5e51e5f1c124a8ed70608b4dbf7376adb2b1bf6a48a65b746076263b2589afe5"
+
+S = "${WORKDIR}/w_scan-${PV}"
+
+inherit autotools
+
+FILES_${PN} += "${datadir}"
+

--- a/meta-multimedia/recipes-mediacentre/xbmc/xbmc/0004-configure-cope-with-ld-is-gold-DISTRO_FEATURE.patch
+++ b/meta-multimedia/recipes-mediacentre/xbmc/xbmc/0004-configure-cope-with-ld-is-gold-DISTRO_FEATURE.patch
@@ -1,0 +1,43 @@
+From fd8f73826240aae543a41a2bfeea0056e2fe594d Mon Sep 17 00:00:00 2001
+From: Koen Kooi <koen@dominion.thruhere.net>
+Date: Mon, 11 Mar 2013 11:04:29 +0100
+Subject: [PATCH] configure: cope with ld-is-gold DISTRO_FEATURE
+
+Signed-off-by: Koen Kooi <koen@dominion.thruhere.net>
+---
+
+Upstream-Stature: backport
+
+ configure.in |   12 +++++++-----
+ 1 files changed, 7 insertions(+), 5 deletions(-)
+
+diff --git a/configure.in b/configure.in
+index ef94683..c8b459b 100755
+--- a/configure.in
++++ b/configure.in
+@@ -18,9 +18,14 @@ tolower(){
+ # check for library basenames
+ AC_DEFUN([XB_FIND_SONAME],
+ [
++  #set -x
+   if [[ "$host_vendor" != "apple" ]]; then
+     AC_MSG_CHECKING([for lib$2 soname])
+     $1_FILENAME=$($CC -nostdlib -o /dev/null $LDFLAGS -l$2 -Wl,-M 2>/dev/null | grep "^LOAD.*$2" | awk '{V=2; print $V}')
++    if [[ -z $$1_FILENAME ]]; then
++      #try gold linker syntax
++      $1_FILENAME=$($CC -nostdlib -o /dev/null $LDFLAGS -l$2 -Wl,-t 3>&1 1>&2 2>&3 | grep "$2")
++    fi
+     if [[ ! -z $$1_FILENAME ]]; then
+       $1_SONAME=$(objdump -p $$1_FILENAME | grep "SONAME.*$2" | awk '{V=2; print $V}')
+     fi
+@@ -55,6 +60,7 @@ AC_DEFUN([XB_FIND_SONAME],
+     AC_MSG_RESULT([$$1_SONAME])
+     AC_SUBST($1_SONAME)
+   fi
++  #set +x
+ ])
+ 
+ # Function to push and pop libs and includes for a command
+-- 
+1.7.7.6
+

--- a/meta-multimedia/recipes-mediacentre/xbmc/xbmc_git.bb
+++ b/meta-multimedia/recipes-mediacentre/xbmc/xbmc_git.bb
@@ -6,6 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE.GPL;md5=6eb631b6da7fdb01508a80213ffc35ff"
 DEPENDS = "libmad libusb1 libcec libplist expat yajl gperf-native libxmu fribidi mpeg2dec ffmpeg samba fontconfig curl python libass libmodplug libmicrohttpd wavpack libmms cmake-native libsdl-image libsdl-mixer virtual/egl mysql5 sqlite3 libmms faad2 libcdio libpcre boost lzo enca avahi libsamplerate0 libxinerama libxrandr libxtst bzip2 virtual/libsdl jasper zip-native zlib libtinyxml"
 #require recipes/egl/egl.inc
 
+
 SRCREV = "82388d55dae79cbb2e486e307e23202e76a43efa"
 
 PV = "11.0"
@@ -30,13 +31,16 @@ CACHED_CONFIGUREVARS += " \
     ac_cv_path_PYTHON="${STAGING_BINDIR_NATIVE}/python-native/python" \
 "
 
+PACKAGECONFIG ??= "${@base_contains('DISTRO_FEATURES', 'opengl', 'opengl', 'openglesv2', d)}"
+PACKAGECONFIG[opengl] = "--enable-gl,--enable-gles,glew"
+PACKAGECONFIG[openglesv2] = "--enable-gles,--enable-gl,"
+
 EXTRA_OECONF = " \
     --disable-rpath \
     --enable-libusb \
     --enable-airplay \
     --disable-optical-drive \
     --enable-external-libraries \
-    ${@base_contains('DISTRO_FEATURES', 'opengl', '--enable-gl', '--enable-gles', d)} \
 "
 
 FULL_OPTIMIZATION_armv7a = "-fexpensive-optimizations -fomit-frame-pointer -O4 -ffast-math"
@@ -79,11 +83,14 @@ FILES_${PN} += "${datadir}/xsessions ${datadir}/icons"
 FILES_${PN}-dbg += "${libdir}/xbmc/.debug ${libdir}/xbmc/*/.debug ${libdir}/xbmc/*/*/.debug ${libdir}/xbmc/*/*/*/.debug"
 
 # xbmc uses some kind of dlopen() method for libcec so we need to add it manually
+# OpenGL builds need glxinfo, that's in mesa-demos
 RRECOMMENDS_${PN}_append = " libcec \
                              python \
                              python-lang \
                              python-re \
                              python-netclient \
                              libcurl \
+                             xdpyinfo \
+                             ${@base_contains('DISTRO_FEATURES', 'opengl', 'mesa-demos', '', d)} \
 "
 RRECOMMENDS_${PN}_append_libc-glibc = " glibc-charmap-ibm850 glibc-gconv-ibm850"

--- a/meta-multimedia/recipes-mediacentre/xbmc/xbmc_git.bb
+++ b/meta-multimedia/recipes-mediacentre/xbmc/xbmc_git.bb
@@ -3,13 +3,13 @@ DESCRIPTION = "XBMC Media Center"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://LICENSE.GPL;md5=6eb631b6da7fdb01508a80213ffc35ff"
 
-DEPENDS = "libusb1 libcec libplist expat yajl gperf-native libxmu fribidi mpeg2dec ffmpeg samba fontconfig curl python libass libmodplug libmicrohttpd wavpack libmms cmake-native libsdl-image libsdl-mixer virtual/egl mysql5 sqlite3 libmms faad2 libcdio libpcre boost lzo enca avahi libsamplerate0 libxinerama libxrandr libxtst bzip2 virtual/libsdl jasper zip-native zlib libtinyxml"
+DEPENDS = "libmad libusb1 libcec libplist expat yajl gperf-native libxmu fribidi mpeg2dec ffmpeg samba fontconfig curl python libass libmodplug libmicrohttpd wavpack libmms cmake-native libsdl-image libsdl-mixer virtual/egl mysql5 sqlite3 libmms faad2 libcdio libpcre boost lzo enca avahi libsamplerate0 libxinerama libxrandr libxtst bzip2 virtual/libsdl jasper zip-native zlib libtinyxml"
 #require recipes/egl/egl.inc
 
 SRCREV = "82388d55dae79cbb2e486e307e23202e76a43efa"
 
 PV = "11.0"
-PR = "r14"
+PR = "r15"
 PR_append = "+gitr${SRCPV}"
 SRC_URI = "git://github.com/xbmc/xbmc.git;branch=eden;protocol=git \
            file://0001-configure-don-t-run-python-distutils-to-find-STAGING.patch \
@@ -26,13 +26,14 @@ CACHED_CONFIGUREVARS += " \
     ac_cv_path_PYTHON="${STAGING_BINDIR_NATIVE}/python-native/python" \
 "
 
+
 EXTRA_OECONF = " \
     --disable-rpath \
-    --enable-gles \
     --enable-libusb \
     --enable-airplay \
     --disable-optical-drive \
     --enable-external-libraries \
+    ${@base_contains('DISTRO_FEATURES', 'opengl', '--enable-gl', '--enable-gles', d)} \
 "
 
 FULL_OPTIMIZATION_armv7a = "-fexpensive-optimizations -fomit-frame-pointer -O4 -ffast-math"

--- a/meta-multimedia/recipes-mediacentre/xbmc/xbmc_git.bb
+++ b/meta-multimedia/recipes-mediacentre/xbmc/xbmc_git.bb
@@ -15,6 +15,7 @@ SRC_URI = "git://github.com/xbmc/xbmc.git;branch=eden;protocol=git \
            file://0001-configure-don-t-run-python-distutils-to-find-STAGING.patch \
            file://0002-Revert-fixed-ios-Add-memory-barriers-to-atomic-Add-S.patch \
            file://0003-Revert-fixed-ios-Add-memory-barriers-to-cas-assembly.patch \
+           file://0004-configure-cope-with-ld-is-gold-DISTRO_FEATURE.patch \
            file://configure.in-Avoid-running-code.patch \
 "
 
@@ -22,10 +23,12 @@ inherit autotools gettext python-dir
 
 S = "${WORKDIR}/git"
 
+# breaks compilation
+CCACHE = ""
+
 CACHED_CONFIGUREVARS += " \
     ac_cv_path_PYTHON="${STAGING_BINDIR_NATIVE}/python-native/python" \
 "
-
 
 EXTRA_OECONF = " \
     --disable-rpath \

--- a/meta-oe/conf/layer.conf
+++ b/meta-oe/conf/layer.conf
@@ -31,3 +31,5 @@ SIGGEN_EXCLUDERECIPES_ABISAFE += " \
   distro-feed-configs \
   ca-certificates \
 "
+
+FREESMARTPHONE_GIT = "git://git.freesmartphone.org"

--- a/meta-xfce/recipes-apps/xfce4-mixer/xfce4-mixer_4.10.0.bb
+++ b/meta-xfce/recipes-apps/xfce4-mixer/xfce4-mixer_4.10.0.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=59530bdf33659b29e73d4adb9f9f6552"
 
 inherit xfce-panel-plugin
 
-DEPENDS += "glib-2.0 gst-plugins-base gtk+ xfconf"
+DEPENDS += "glib-2.0 gst-plugins-base gtk+ xfconf libunique"
 
 SRC_URI = "http://archive.xfce.org/src/apps/${BPN}/${@xfce_verdir("${PV}")}/${BPN}-${PV}.tar.bz2"
 


### PR DESCRIPTION
FREESMARTPHONE_GIT used to be defined in bitbake.conf of 'openembedded-core' layer, but recently it was removed from there which broke several recipes in 'meta-oe' that still use it, such as:
- recipes-support/serial-utils/pty-forward-native.bb
- recipes-support/serial-utils/serial-forward_git.bb
- recipes-support/vala-terminal/vala-terminal_git.bb
- recipes-devtools/vala-dbus-binding-tool/vala-dbus-binding-tool_git.bb
