### PR TITLE
Added pyserial version 2.7

### DIFF
--- a/meta-oe/recipes-devtools/python/python-pyserial_2.7.bb
+++ b/meta-oe/recipes-devtools/python/python-pyserial_2.7.bb
@@ -1,0 +1,23 @@
+DESCRIPTION = "Serial Port Support for Python"
+SECTION = "devel/python"
+LICENSE = "PSF"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=c557c64905dac5b725980b9505bf8d7b"
+SRCNAME = "pyserial"
+PR = "ml4"
+
+SRC_URI = "${SOURCEFORGE_MIRROR}/${SRCNAME}/${SRCNAME}-${PV}.tar.gz"
+S = "${WORKDIR}/${SRCNAME}-${PV}"
+
+inherit setuptools
+
+# FIXME might stop packaging serialwin32 and serialjava files
+
+RDEPENDS_${PN} = "\
+    python-fcntl \
+    python-io \
+    python-stringold \
+"
+
+SRC_URI[md5sum] = "794506184df83ef2290de0d18803dd11"
+SRC_URI[sha256sum] = "3542ec0838793e61d6224e27ff05e8ce4ba5a5c5cc4ec5c6a3e8d49247985477"
+


### PR DESCRIPTION
Added recipe for pyserial_2.7 to provide up-to-date serial functionality in python 2.7.
